### PR TITLE
AdminBoardListDto update

### DIFF
--- a/back-end/plantrowth/src/main/java/com/opinio/plantrowth/api/dto/admin/AdminBoardListDto.java
+++ b/back-end/plantrowth/src/main/java/com/opinio/plantrowth/api/dto/admin/AdminBoardListDto.java
@@ -6,6 +6,7 @@ import lombok.*;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -23,15 +24,22 @@ public class AdminBoardListDto {
     private LocalDateTime updateDate;
     private String filename;
     private Boolean isBlocked;
-    private List<ReportDto> reports;
-
-    public static class ReportDto{
+    private Long writerId;
+    private String writerName;
+    private Integer countedReports;
+    private List<AdminReportDto> reports;
+    @Data
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Getter
+    @Setter
+    public class AdminReportDto{
         private Long reportId;
         private String reason;
         private LocalDate date;
         private Enum state;
         private Enum tag;
-        public ReportDto(Report report){
+        public AdminReportDto(Report report){
             reportId = report.getId();
             reason = report.getReason();
             date = report.getDate();
@@ -47,9 +55,12 @@ public class AdminBoardListDto {
         updateDate = board.getUpdateDate();
         filename = board.getFilename();
         isBlocked = board.getIsBlocked();
+        writerId = board.getUser().getId();
+        writerName = board.getUser().getName();
+        countedReports = board.getReports().size();
         reports = board.getReports()
                 .stream()
-                .map(report -> new ReportDto(report))
+                .map(report -> new AdminReportDto(report))
                 .collect(Collectors.toList());
     }
 }


### PR DESCRIPTION
1. AdminBoardListDto의 하위항목인 ReportsDto를 AdminReportsDto로 rename 및 어노테이션 추가.
2. 신고 갯수 셀수있는 countedReports추가
3. 게시글 작성자를 알 수 있는 writer_id, writer_name 추가